### PR TITLE
Deregisters last view controller from being observed before being sent back to main window

### DIFF
--- a/DPSetupWindow.m
+++ b/DPSetupWindow.m
@@ -159,7 +159,7 @@ typedef enum {
 	
 	NSInteger nextStage = currentStage + direction;
 	if (nextStage == [[self viewControllers] count]) {
-        [self deregisterObserversForViewController:previousViewController];
+        	[self deregisterObserversForViewController:previousViewController];
 		[self completionHandler](YES);
 		return;
 	}
@@ -259,10 +259,9 @@ typedef enum {
 	[nextViewController addObserver:self forKeyPath:@"canGoBack" options:(NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld) context:NULL];
 }
 
-- (void)deregisterObserversForViewController:(NSViewController *)viewController
-{
-    [viewController removeObserver:self forKeyPath:@"canContinue"];
-    [viewController removeObserver:self forKeyPath:@"canGoBack"];
+- (void)deregisterObserversForViewController:(NSViewController *)viewController {
+    	[viewController removeObserver:self forKeyPath:@"canContinue"];
+    	[viewController removeObserver:self forKeyPath:@"canGoBack"];
 }
 
 - (void)resetButtonTitles {

--- a/DPSetupWindow.m
+++ b/DPSetupWindow.m
@@ -159,6 +159,7 @@ typedef enum {
 	
 	NSInteger nextStage = currentStage + direction;
 	if (nextStage == [[self viewControllers] count]) {
+        [self deregisterObserversForViewController:previousViewController];
 		[self completionHandler](YES);
 		return;
 	}
@@ -256,6 +257,12 @@ typedef enum {
 	[previousViewController removeObserver:self forKeyPath:@"canGoBack"];
 	[nextViewController addObserver:self forKeyPath:@"canContinue" options:(NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld) context:NULL];
 	[nextViewController addObserver:self forKeyPath:@"canGoBack" options:(NSKeyValueObservingOptionNew|NSKeyValueObservingOptionOld) context:NULL];
+}
+
+- (void)deregisterObserversForViewController:(NSViewController *)viewController
+{
+    [viewController removeObserver:self forKeyPath:@"canContinue"];
+    [viewController removeObserver:self forKeyPath:@"canGoBack"];
 }
 
 - (void)resetButtonTitles {


### PR DESCRIPTION
Great little Cocoa class btw.

This fix is for a bug for when an NSPersistentDocument instance is setting up DPSetupWindow, once the DPSetupWindow's sheet ends through the "Continue" (ie. not "Cancel") button, the last view controller isn't deregistered as being observed by the DPSetupWindow instance.

This caused NSPersistentDocument to crash, and not allow the document to be saved, etc.

I'm quite new at this, but this "fix" seemed to allow the NSPersistentDocument to reacquire control and save/quit the application gracefully/etc.

Let me know.

SC
